### PR TITLE
Load translations at `plugins_loaded` instead of `admin_init`

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -92,9 +92,6 @@ class MC4WP_Lite_Admin
 		register_setting( 'mc4wp_lite_checkbox_settings', 'mc4wp_lite_checkbox', array( $this, 'validate_checkbox_settings' ) );
 		register_setting( 'mc4wp_lite_form_settings', 'mc4wp_lite_form', array( $this, 'validate_form_settings' ) );
 
-		// load the plugin text domain
-		load_plugin_textdomain( 'mailchimp-for-wp', false, dirname( $this->plugin_file ) . '/languages/' );
-
 		// store whether this plugin has the BWS captcha plugin running (https://wordpress.org/plugins/captcha/)
 		$this->has_captcha_plugin = function_exists( 'cptch_display_captcha_custom' );
 

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -52,6 +52,9 @@ function mc4wp_load_plugin() {
 	define( 'MC4WP_LITE_PLUGIN_URL', plugins_url( '/' , __FILE__ ) );
 	define( 'MC4WP_LITE_PLUGIN_FILE', __FILE__ );
 
+	// load translations
+	load_plugin_textdomain( 'mailchimp-for-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/functions/general.php';
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/functions/template.php';
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/class-plugin.php';

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -52,15 +52,14 @@ function mc4wp_load_plugin() {
 	define( 'MC4WP_LITE_PLUGIN_URL', plugins_url( '/' , __FILE__ ) );
 	define( 'MC4WP_LITE_PLUGIN_FILE', __FILE__ );
 
-	// load translations
-	load_plugin_textdomain( 'mailchimp-for-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/functions/general.php';
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/functions/template.php';
 	require_once MC4WP_LITE_PLUGIN_DIR . 'includes/class-plugin.php';
 	$GLOBALS['mc4wp'] = new MC4WP_Lite();
 
 	if( is_admin() && ( false === defined( 'DOING_AJAX' ) || false === DOING_AJAX ) ) {
+		// load translations
+		load_plugin_textdomain( 'mailchimp-for-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
 		// ADMIN
 		require_once MC4WP_LITE_PLUGIN_DIR . 'includes/class-admin.php';


### PR DESCRIPTION
The `admin_init` is too late to load the translations (at least that's my guess). The translations did not get loaded on my installation. By looking at the [codex for `load_plugin_textdomain`](https://codex.wordpress.org/Function_Reference/load_plugin_textdomain), it is recommended to load it at the `plugins_loaded` action. With this fix everything works fine for me.

Thanks to @podlebar for pointing me in the right direction here.

WDYT?