### PR TITLE
Determine plugin dir dynamically

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -17,12 +17,14 @@ class MC4WP_Lite_Admin
 	/**
 	 * @var string The relative path to the main plugin file from the plugins dir
 	 */
-	private $plugin_file = 'mailchimp-for-wp/mailchimp-for-wp.php';
+	private $plugin_file;
 
 	/**
 	 * Constructor
 	 */
 	public function __construct() {
+
+		$this->plugin_file = plugin_basename( MC4WP_LITE_PLUGIN_FILE );
 
 		$this->load_translations();
 		$this->setup_hooks();


### PR DESCRIPTION
When I fetched your change to load the translation it didn't still didn't work for me, but I finally found out why that is. I installed your plugin from GitHub, my plugin dir was thus named "mailchimp-for-wordpress", but your code assumes it's "mailchimp-for-wp". This PR sets the `plugin_file` variable by using the `plugin_basename` function. Now finally my German translations show up :wink: